### PR TITLE
Fix header timestamp overflow

### DIFF
--- a/sfu/src/local_track.rs
+++ b/sfu/src/local_track.rs
@@ -107,6 +107,8 @@ impl LocalTrack {
                             let old_timestamp = rtp.header.timestamp;
                             if last_timestamp == 0 {
                                 rtp.header.timestamp = 0
+                            } else if rtp.header.timestamp < last_timestamp {
+                                rtp.header.timestamp = 0
                             } else {
                                 rtp.header.timestamp -= last_timestamp;
                             }


### PR DESCRIPTION
```
thread 'actix-rt|system:0|arbiter:0' panicked at src/local_track.rs:111:33:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```