### PR TITLE
Add replay channel to store published tracks

### DIFF
--- a/sfu/src/lib.rs
+++ b/sfu/src/lib.rs
@@ -22,6 +22,7 @@ pub mod publish_transport;
 /// Audio and video methods for track.
 pub mod publisher;
 pub mod relay;
+mod replay_channel;
 /// Router is a module that determines which media to distribute to whom.
 pub mod router;
 pub mod rtp;

--- a/sfu/src/replay_channel.rs
+++ b/sfu/src/replay_channel.rs
@@ -1,0 +1,41 @@
+use std::{collections::VecDeque, sync::Arc};
+
+use tokio::sync::{mpsc, Mutex};
+
+#[derive(Debug)]
+pub(crate) struct ReplayChannel<T> {
+    history: Arc<Mutex<VecDeque<T>>>,
+    sender: mpsc::Sender<T>,
+    capacity: usize,
+}
+
+impl<T: Clone + Send + 'static> ReplayChannel<T> {
+    pub fn new(capacity: usize) -> (Self, mpsc::Receiver<T>) {
+        let (sender, receiver) = mpsc::channel(1024);
+        let history = Arc::new(Mutex::new(VecDeque::with_capacity(capacity)));
+        (
+            Self {
+                history,
+                sender,
+                capacity,
+            },
+            receiver,
+        )
+    }
+
+    pub async fn send(&self, msg: T) {
+        {
+            let mut history = self.history.lock().await;
+            if history.len() == self.capacity {
+                history.pop_front();
+            }
+            history.push_back(msg.clone());
+        }
+        let _ = self.sender.send(msg).await;
+    }
+
+    pub async fn subscribe(&self) -> Vec<T> {
+        let history = self.history.lock().await;
+        history.iter().cloned().collect()
+    }
+}


### PR DESCRIPTION
If `publish` method is called after `on_track` events,  `publish` method will not succeed. Because `tokio::sync::broadcast` can't store past events.