### PR TITLE
Launch relay udp server for each router to improve performance

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,7 +6,7 @@ const config: PlaywrightTestConfig = {
   workers: 1,
   use: {
     locale: "en-US",
-    headless: true,
+    headless: process.env.HEADLESS !== "false",
   },
   projects: [
     {

--- a/sfu/Cargo.lock
+++ b/sfu/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.0",
+ "rand 0.9.1",
  "sha1",
  "smallvec",
  "tokio",
@@ -1569,6 +1569,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openport"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "365c699f76305b3e62588961a288be10f0819ef1391f25870a69b35a213577cc"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,12 +1722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "port_check"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2110609fb863cdb367d4e69d6c43c81ba6a8c7d18e80082fe9f3ef16b23afeed"
-
-[[package]]
 name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,13 +1794,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy",
 ]
 
 [[package]]
@@ -1956,7 +1958,8 @@ dependencies = [
  "derivative",
  "enclose",
  "futures-util",
- "port_check",
+ "openport",
+ "rand 0.9.1",
  "redis",
  "serde",
  "serde_json",
@@ -3091,26 +3094,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
 ]
 
 [[package]]

--- a/sfu/Cargo.toml
+++ b/sfu/Cargo.toml
@@ -14,7 +14,8 @@ bitvec = "1.0"
 bytes = "1.9"
 derivative = "2.2"
 enclose = "1.2"
-port_check = "0.2.1"
+openport = { version = "0.1.1", features = ["rand"] }
+rand = "0.9.1"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 strum = { version = "0.27", features = ["derive"]}

--- a/sfu/src/relay/data.rs
+++ b/sfu/src/relay/data.rs
@@ -1,3 +1,4 @@
+use bincode::{Decode, Encode};
 use bytes::{Bytes, BytesMut};
 
 use serde::{Deserialize, Serialize};
@@ -108,6 +109,11 @@ impl From<RTCRtpCodecCapabilitySerializable> for RTCRtpCodecCapability {
             rtcp_feedback: value.rtcp_feedback.into_iter().map(|f| f.into()).collect(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, PartialEq)]
+pub(crate) struct UDPStarted {
+    pub(crate) port: u16,
 }
 
 #[derive(Debug, Clone)]

--- a/sfu/src/relay/receiver.rs
+++ b/sfu/src/relay/receiver.rs
@@ -15,8 +15,11 @@ use crate::{
         relayed_publisher::RelayedPublisher,
     },
     track::Track,
+    utils::ports::find_unused_port,
     worker::Worker,
 };
+
+use super::data::UDPStarted;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 struct RouterId(String);
@@ -26,31 +29,29 @@ struct PublisherId(String);
 
 #[derive(Debug)]
 pub(crate) struct RelayServer {
-    udp_socket: UdpSocket,
     tcp_listener: TcpListener,
     worker: Arc<Mutex<Worker>>,
     stop_sender: broadcast::Sender<bool>,
-    publishers: Arc<Mutex<HashMap<PublisherId, HashMap<RouterId, Arc<Mutex<RelayedPublisher>>>>>>,
-    udp_port: u16,
+    publishers: Arc<
+        Mutex<HashMap<RouterId, Arc<Mutex<HashMap<PublisherId, Arc<Mutex<RelayedPublisher>>>>>>>,
+    >,
+    udp_servers: Arc<Mutex<HashMap<RouterId, Arc<Mutex<RelayUDPServer>>>>>,
 }
 
 impl RelayServer {
     pub(crate) async fn new(
-        udp_port: u16,
         tcp_port: u16,
         worker: Arc<Mutex<Worker>>,
         stop_sender: broadcast::Sender<bool>,
     ) -> Result<Self, Error> {
-        let udp_socket = UdpSocket::bind(format!("0.0.0.0:{}", udp_port)).await?;
         let tcp_listener = TcpListener::bind(format!("0.0.0.0:{}", tcp_port)).await?;
 
         Ok(Self {
-            udp_socket,
             tcp_listener,
             worker,
             stop_sender,
             publishers: Arc::new(Mutex::new(HashMap::new())),
-            udp_port,
+            udp_servers: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -83,6 +84,7 @@ impl RelayServer {
             match serde_json::from_slice::<TrackData>(&buffer[..n]) {
                 Ok(data) => {
                     let res = self.handle_tcp_message(data).await;
+                    tracing::debug!("TCP response: {:#?}", res);
                     let byte = bincode::encode_to_vec(res, bincode::config::standard()).unwrap();
                     stream.write_all(&byte).await?;
                 }
@@ -110,26 +112,35 @@ impl RelayServer {
                 None => {
                     return TCPResponse {
                         status: "error".to_string(),
-                        message: "router not found".to_string(),
-                        port: None,
+                        message: Some("router not found".to_string()),
+                        udp_started: None,
                     }
                 }
             }
 
             let mut publishers = self.publishers.lock().await;
 
-            if let Some(router_publisher) = publishers.get(&publisher_id) {
-                if let Some(publisher) = router_publisher.get(&router_id) {
+            if let Some(router_publisher) = publishers.get(&router_id) {
+                if let Some(publisher) = router_publisher.lock().await.get(&publisher_id) {
                     let locked = publisher.lock().await;
                     locked.close();
                 }
             }
-            publishers.remove(&publisher_id);
+            if let Some(router_publisher) = publishers.get_mut(&router_id) {
+                router_publisher.lock().await.remove(&publisher_id);
+                if router_publisher.lock().await.is_empty() {
+                    // Stop UDP receiver server if no publishers left
+                    if let Some(udp_server) = self.udp_servers.lock().await.get(&router_id) {
+                        udp_server.lock().await.close();
+                    }
+                    publishers.remove(&router_id);
+                }
+            }
 
             return TCPResponse {
                 status: "ok".to_string(),
-                message: "publisher removed".to_string(),
-                port: None,
+                message: Some("publisher removed".to_string()),
+                udp_started: None,
             };
         } else {
             let locked = self.worker.lock().await;
@@ -138,25 +149,13 @@ impl RelayServer {
                     tracing::debug!("router id={} is found", data.router_id);
 
                     let mut publishers = self.publishers.lock().await;
-                    if let Some(publisher) = publishers
-                        .get(&publisher_id)
-                        .and_then(|p| p.get(&router_id))
-                    {
-                        let mut publisher = publisher.lock().await;
-                        publisher.publisher_type = data.publisher_type;
-                        publisher.create_relayed_track(
-                            data.track_id.clone(),
-                            data.ssrc,
-                            data.rid,
-                            data.mime_type,
-                            data.codec_parameters.into(),
-                            data.stream_id,
-                        );
-                    } else {
-                        let publisher =
-                            RelayedPublisher::new(data.track_id.clone(), data.publisher_type);
-                        {
-                            let publisher = publisher.lock().await;
+                    if let Some(router_publisher) = publishers.get_mut(&router_id) {
+                        if let Some(publisher) = router_publisher.lock().await.get(&publisher_id) {
+                            // For simulcast.
+                            // If this server receives another track with the same track_id, it is a simulcast track with another resolution.
+                            // It should be the same track_id, but different ssrc and rid.
+                            let mut publisher = publisher.lock().await;
+                            publisher.publisher_type = data.publisher_type;
                             publisher.create_relayed_track(
                                 data.track_id.clone(),
                                 data.ssrc,
@@ -165,82 +164,201 @@ impl RelayServer {
                                 data.codec_parameters.into(),
                                 data.stream_id,
                             );
-                        }
-
-                        {
-                            let mut router = router.lock().await;
-                            router
-                                .add_relayed_publisher(data.track_id.clone(), publisher.clone())
-                                .await;
-                        }
-
-                        if let Some(router_publisher) = publishers.get_mut(&publisher_id) {
-                            router_publisher.insert(router_id.clone(), publisher.clone());
                         } else {
-                            publishers.insert(
-                                publisher_id.clone(),
-                                HashMap::from([(router_id.clone(), publisher.clone())]),
-                            );
+                            let publisher = self.create_publisher(&data).await;
+
+                            {
+                                let mut router = router.lock().await;
+                                router
+                                    .add_relayed_publisher(data.track_id.clone(), publisher.clone())
+                                    .await;
+                            }
+                            router_publisher
+                                .lock()
+                                .await
+                                .insert(publisher_id.clone(), publisher.clone());
                         }
+                    } else {
+                        if let Some(udp_port) = find_unused_port() {
+                            let publisher = self.create_publisher(&data).await;
+
+                            {
+                                let mut router = router.lock().await;
+                                router
+                                    .add_relayed_publisher(data.track_id.clone(), publisher.clone())
+                                    .await;
+                            }
+
+                            publishers.insert(
+                                router_id.clone(),
+                                Arc::new(Mutex::new(HashMap::from([(
+                                    publisher_id.clone(),
+                                    publisher.clone(),
+                                )]))),
+                            );
+
+                            let p = publishers.get(&router_id).cloned().unwrap_or_default();
+                            match RelayUDPServer::new(udp_port, p).await {
+                                Ok(udp) => {
+                                    let mut udp_servers = self.udp_servers.lock().await;
+                                    udp_servers
+                                        .insert(router_id.clone(), Arc::new(Mutex::new(udp)));
+                                }
+                                Err(err) => {
+                                    tracing::error!("Failed to create UDP server: {}", err);
+                                    return TCPResponse {
+                                        status: "error".to_string(),
+                                        message: Some("failed to create UDP server".to_string()),
+                                        udp_started: None,
+                                    };
+                                }
+                            }
+                        } else {
+                            tracing::error!("No free UDP port found for router {}", data.router_id);
+                            return TCPResponse {
+                                status: "error".to_string(),
+                                message: Some("no free UDP port found".to_string()),
+                                udp_started: None,
+                            };
+                        }
+                    }
+
+                    let udp_server_port: u16;
+                    if let Some(udp_server) = self.udp_servers.lock().await.get(&router_id) {
+                        udp_server_port = udp_server.lock().await.udp_port;
+                    } else {
+                        tracing::error!("No UDP server found for router {}", data.router_id);
+                        return TCPResponse {
+                            status: "error".to_string(),
+                            message: Some("no UDP server found".to_string()),
+                            udp_started: None,
+                        };
                     }
 
                     return TCPResponse {
                         status: "ok".to_string(),
-                        message: "publisher added".to_string(),
-                        port: Some(self.udp_port),
+                        message: None,
+                        udp_started: Some(UDPStarted {
+                            port: udp_server_port,
+                        }),
                     };
                 }
                 None => {
                     tracing::warn!("router id={} is not found", data.router_id);
                     return TCPResponse {
                         status: "error".to_string(),
-                        message: "router not found".to_string(),
-                        port: None,
+                        message: Some("router not found".to_string()),
+                        udp_started: None,
                     };
                 }
             }
         }
     }
 
-    pub(crate) async fn run_udp(&self) -> Result<bool, Error> {
-        loop {
-            let mut buf = [0u8; 1500];
-            let (len, _addr) = self.udp_socket.recv_from(&mut buf).await?;
-
-            let bytes = Bytes::copy_from_slice(&buf[..len]);
-            let packet_data = PacketData::unmarshal(&bytes, len)?;
-
-            tracing::trace!("packet received with udp: {:#?}", packet_data);
-
-            let publisher_id = PublisherId(packet_data.track_id.clone());
-
-            let publishers = self.publishers.lock().await;
-            if let Some(router_publisher) = publishers.get(&publisher_id) {
-                for (_router_id, publisher) in router_publisher.iter() {
-                    let data = packet_data.clone();
-                    let publisher = publisher.lock().await;
-                    if let Some(track) = publisher.local_tracks.get(&data.ssrc) {
-                        let rtp_packet_sender = track.rtp_packet_sender();
-                        if rtp_packet_sender.receiver_count() > 0 {
-                            if let Err(err) = rtp_packet_sender.send((data.packet, data.layer)) {
-                                tracing::error!(
-                                    "RelayedTrack id={} ssrc={} failed to send rtp: {}",
-                                    data.track_id,
-                                    data.ssrc,
-                                    err
-                                );
-                            }
-                        }
-                    }
-                }
-            }
+    async fn create_publisher(&self, data: &TrackData) -> Arc<Mutex<RelayedPublisher>> {
+        let publisher = RelayedPublisher::new(data.track_id.clone(), data.publisher_type.clone());
+        {
+            let publisher = publisher.lock().await;
+            publisher.create_relayed_track(
+                data.track_id.clone(),
+                data.ssrc,
+                data.rid.clone(),
+                data.mime_type.clone(),
+                data.codec_parameters.clone().into(),
+                data.stream_id.clone(),
+            );
         }
+        publisher
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub(crate) struct TCPResponse {
     pub(crate) status: String,
-    pub(crate) message: String,
-    pub(crate) port: Option<u16>,
+    pub(crate) udp_started: Option<UDPStarted>,
+    pub(crate) message: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct RelayUDPServer {
+    pub(crate) udp_port: u16,
+    closed: broadcast::Sender<bool>,
+}
+
+impl RelayUDPServer {
+    async fn new(
+        udp_port: u16,
+        publishers: Arc<Mutex<HashMap<PublisherId, Arc<Mutex<RelayedPublisher>>>>>,
+    ) -> Result<Self, Error> {
+        let (closed_sender, _closed_receiver) = broadcast::channel(1);
+
+        {
+            let closed_sender = closed_sender.clone();
+            tokio::spawn(async move {
+                if let Err(err) = Self::run_udp(udp_port, publishers, closed_sender.clone()).await {
+                    tracing::error!("UDP server error: {}", err);
+                }
+            });
+        }
+
+        Ok(Self {
+            udp_port,
+            closed: closed_sender,
+        })
+    }
+
+    async fn run_udp(
+        udp_port: u16,
+        publishers: Arc<Mutex<HashMap<PublisherId, Arc<Mutex<RelayedPublisher>>>>>,
+        closed_sender: broadcast::Sender<bool>,
+    ) -> Result<bool, Error> {
+        let mut closed_receiver = closed_sender.subscribe();
+        let udp_socket = UdpSocket::bind(format!("0.0.0.0:{}", udp_port)).await?;
+        tracing::info!("UDP server started on :{}", udp_port);
+
+        loop {
+            let mut buf = [0u8; 1500];
+
+            tokio::select! {
+                _ = closed_receiver.recv() => {
+                    tracing::info!("UDP server on :{} is closed", udp_port);
+                    break;
+                }
+                res = udp_socket.recv_from(&mut buf) => {
+                    let (len, _addr) = res?;
+                    let bytes = Bytes::copy_from_slice(&buf[..len]);
+                    let packet_data = PacketData::unmarshal(&bytes, len)?;
+
+                    tracing::trace!("packet received with udp: {:#?}", packet_data);
+
+                    let publisher_id = PublisherId(packet_data.track_id.clone());
+
+                    let publishers = publishers.lock().await;
+                    if let Some(publisher) = publishers.get(&publisher_id) {
+                        let data = packet_data.clone();
+                        let publisher = publisher.lock().await;
+                        if let Some(track) = publisher.local_tracks.get(&data.ssrc) {
+                            let rtp_packet_sender = track.rtp_packet_sender();
+                            if rtp_packet_sender.receiver_count() > 0 {
+                                if let Err(err) = rtp_packet_sender.send((data.packet, data.layer)) {
+                                    tracing::error!(
+                                        "RelayedTrack id={} ssrc={} failed to send rtp: {}",
+                                        data.track_id,
+                                        data.ssrc,
+                                        err
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
+    pub(crate) fn close(&self) {
+        self.closed.send(true).unwrap();
+    }
 }

--- a/sfu/src/relay/receiver.rs
+++ b/sfu/src/relay/receiver.rs
@@ -130,8 +130,10 @@ impl RelayServer {
                 router_publisher.lock().await.remove(&publisher_id);
                 if router_publisher.lock().await.is_empty() {
                     // Stop UDP receiver server if no publishers left
-                    if let Some(udp_server) = self.udp_servers.lock().await.get(&router_id) {
+                    let mut servers = self.udp_servers.lock().await;
+                    if let Some(udp_server) = servers.get(&router_id) {
                         udp_server.lock().await.close();
+                        servers.remove(&router_id);
                     }
                     publishers.remove(&router_id);
                 }

--- a/sfu/src/relay/relayed_publisher.rs
+++ b/sfu/src/relay/relayed_publisher.rs
@@ -39,6 +39,8 @@ impl RelayedPublisher {
 
         let publisher = Arc::new(Mutex::new(publisher));
 
+        tracing::debug!("RelayedPublisher {} created", track_id,);
+
         {
             let publisher = publisher.clone();
             tokio::spawn(async move {
@@ -60,7 +62,7 @@ impl RelayedPublisher {
     ) {
         if let None = self.local_tracks.get(&ssrc) {
             let local_track = RelayedTrack::new(
-                track_id,
+                track_id.clone(),
                 ssrc,
                 rid.clone(),
                 mime_type,
@@ -71,9 +73,15 @@ impl RelayedPublisher {
                 .publisher_event_sender
                 .send(RelayedPublisherEvent::TrackAdded(
                     ssrc,
-                    rid,
+                    rid.clone(),
                     Arc::new(local_track),
                 ));
+            tracing::debug!(
+                "RelayedTrack is created with track_id={}, ssrc={}, rid={}",
+                track_id,
+                ssrc,
+                rid
+            );
         }
     }
 

--- a/sfu/src/utils/ports.rs
+++ b/sfu/src/utils/ports.rs
@@ -1,6 +1,12 @@
-use port_check::free_local_port_in_range;
+use openport::{is_free_udp, pick_unused_port};
 
 pub(crate) fn find_unused_port() -> Option<u16> {
-    let free_port = free_local_port_in_range(10000..=65535);
-    free_port
+    for _n in 0..100 {
+        if let Some(port) = pick_unused_port(15000..65535) {
+            if is_free_udp(port) {
+                return Some(port);
+            }
+        }
+    }
+    None
 }

--- a/sfu/src/worker.rs
+++ b/sfu/src/worker.rs
@@ -42,13 +42,8 @@ impl Worker {
         }
 
         {
-            let relay_server = RelayServer::new(
-                config.relay_server_udp_port,
-                config.relay_server_tcp_port,
-                worker.clone(),
-                stop_sender,
-            )
-            .await?;
+            let relay_server =
+                RelayServer::new(config.relay_server_tcp_port, worker.clone(), stop_sender).await?;
             let relay_server = Arc::new(relay_server);
 
             {
@@ -59,12 +54,6 @@ impl Worker {
                     }
                 });
             }
-
-            tokio::spawn(async move {
-                if let Err(err) = relay_server.run_udp().await {
-                    tracing::error!("Relay server UDP error: {}", err);
-                }
-            });
         }
 
         Ok(worker)


### PR DESCRIPTION
Originally, only one UDP server was launched when the worker was initialized. However, all relayed UDP packets were handled by one process (= UDP server). 
In this PR, I separate UDP servers per target router. As a result, multiple UDP servers will be launched when relays are requested.